### PR TITLE
Nova classe para auxiliar em operações entre a nova API de data de Java 8 e o antigo java.util.Date

### DIFF
--- a/src/main/java/br/com/doit/commons/time/DateUtils.java
+++ b/src/main/java/br/com/doit/commons/time/DateUtils.java
@@ -1,0 +1,29 @@
+package br.com.doit.commons.time;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
+
+/**
+ * Classe utilitária para ajudar na conversão de objetos da nova API de data de Java 8 (pacote {@code java.time}) para o
+ * antigo {@code java.util.Date}.
+ *
+ * @author <a href="mailto:hprange@gmail.com">Henrique Prange</a>
+ */
+public class DateUtils {
+    /**
+     * Converte um {@code java.time.LocalDate} para {@code java.util.Date} usando o timezone definido pelo sistema.
+     *
+     * @param localDate
+     *            Uma data (pode ser nula).
+     * @return Retorna um {@code java.util.Date} para a data informada ou {@code null} caso nenhuma data tenha sido
+     *         informada.
+     */
+    public static Date toDate(LocalDate localDate) {
+        if (localDate == null) {
+            return null;
+        }
+
+        return Date.from(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant());
+    }
+}

--- a/src/main/java/br/com/doit/commons/time/DateUtils.java
+++ b/src/main/java/br/com/doit/commons/time/DateUtils.java
@@ -26,4 +26,12 @@ public class DateUtils {
 
         return Date.from(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant());
     }
+
+    public static LocalDate toLocalDate(Date date) {
+        if (date == null) {
+            return null;
+        }
+
+        return date.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+    }
 }

--- a/src/main/java/br/com/doit/commons/time/DateUtils.java
+++ b/src/main/java/br/com/doit/commons/time/DateUtils.java
@@ -27,6 +27,14 @@ public class DateUtils {
         return Date.from(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant());
     }
 
+    /**
+     * Converte um {@code java.util.Date} para {@code java.time.LocalDate} usando o timezone definido pelo sistema.
+     *
+     * @param date
+     *            Uma data (pode ser nula).
+     * @return Retorna um {@code java.time.LocalDate} para a data informada ou {@code null} caso nenhuma data tenha sido
+     *         informada.
+     */
     public static LocalDate toLocalDate(Date date) {
         if (date == null) {
             return null;

--- a/src/test/java/br/com/doit/commons/time/TestDateUtils.java
+++ b/src/test/java/br/com/doit/commons/time/TestDateUtils.java
@@ -1,0 +1,41 @@
+package br.com.doit.commons.time;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import java.time.LocalDate;
+import java.util.Calendar;
+import java.util.Date;
+
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:hprange@gmail.com">Henrique Prange</a>
+ */
+public class TestDateUtils {
+    @Test
+    public void createDateWithDefaultTimeZoneWhenConvertingFromLocalDate() throws Exception {
+        LocalDate localDate = LocalDate.of(1983, 1, 7);
+
+        Date result = DateUtils.toDate(localDate);
+
+        Calendar calendar = Calendar.getInstance();
+
+        calendar.setTime(result);
+
+        assertThat(calendar.get(Calendar.YEAR), is(1983));
+        assertThat(calendar.get(Calendar.MONTH), is(0));
+        assertThat(calendar.get(Calendar.DAY_OF_MONTH), is(7));
+        assertThat(calendar.get(Calendar.HOUR_OF_DAY), is(0));
+        assertThat(calendar.get(Calendar.MINUTE), is(0));
+        assertThat(calendar.get(Calendar.SECOND), is(0));
+    }
+
+    @Test
+    public void returnNullWhenConvertingFromNullLocalDate() throws Exception {
+        Date result = DateUtils.toDate(null);
+
+        assertThat(result, nullValue());
+    }
+}

--- a/src/test/java/br/com/doit/commons/time/TestDateUtils.java
+++ b/src/test/java/br/com/doit/commons/time/TestDateUtils.java
@@ -4,6 +4,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 
+import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.util.Calendar;
 import java.util.Date;
@@ -33,8 +34,24 @@ public class TestDateUtils {
     }
 
     @Test
-    public void returnNullWhenConvertingFromNullLocalDate() throws Exception {
+    public void returnNullWhenConvertingFromNullLocalDateToDate() throws Exception {
         Date result = DateUtils.toDate(null);
+
+        assertThat(result, nullValue());
+    }
+
+    @Test
+    public void createLocalDateWithDefaultTimeZoneWhenConvertingFromDate() throws Exception {
+        Date date = new SimpleDateFormat("yyyy-MM-dd").parse("1983-01-07");
+
+        LocalDate result = DateUtils.toLocalDate(date);
+
+        assertThat(result, is(LocalDate.of(1983, 1, 7)));
+    }
+
+    @Test
+    public void returnNullWhenConvertingFromNullDateToLocalDate() throws Exception {
+        LocalDate result = DateUtils.toLocalDate(null);
 
         assertThat(result, nullValue());
     }


### PR DESCRIPTION
- Permite converter um `java.time.LocalDate` para `java.util.Date` usando o timezone padrão de forma simples.
- Permite converter um `java.util.Date` em `java.time.LocalDate` usando o timezone padrão de forma simples.