### PR TITLE
Adiciona Collector para fazer somatória de BigDecimals

### DIFF
--- a/src/main/java/br/com/doit/commons/stream/AbstractBigDecimalCollector.java
+++ b/src/main/java/br/com/doit/commons/stream/AbstractBigDecimalCollector.java
@@ -1,0 +1,58 @@
+package br.com.doit.commons.stream;
+
+import static java.util.stream.Collectors.collectingAndThen;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.stream.Collector;
+
+/**
+ * Essa classe contém a implentação básica da interface {@code BigDecimalCollector} e pode ser usada como base para
+ * classes que queiram implementá-la.
+ *
+ * @author <a href="mailto:hprange@gmail.com">Henrique Prange</a>
+ */
+abstract class AbstractBigDecimalCollector<T, R> implements BigDecimalCollector<T, BigDecimalAccumulator, R> {
+    private BinaryOperator<BigDecimal> divide = (dividend, divisor) -> dividend.divide(divisor);
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see br.com.doit.commons.stream.BigDecimalCollector#withScale(int, java.math.RoundingMode)
+     */
+    @Override
+    public Collector<T, BigDecimalAccumulator, R> withScale(int scale, RoundingMode roundingMode) {
+        Function<R, R> rounding = map(v -> v.setScale(scale, roundingMode));
+
+        // Isso é necessário pois uma divisão que gere uma dízima periódica deve ser arredondada no momento da divisão
+        // não depois
+        divide = (dividend, divisor) -> dividend.divide(divisor, scale, roundingMode);
+
+        return collectingAndThen(this, rounding);
+    }
+
+    /**
+     * Operação de divisão que pode conter ou não arredondamento.
+     *
+     * @param dividend
+     *            O valor que será dividido.
+     * @param divisor
+     *            O valor que será usado para fazer a divisão.
+     * @return Retorna o resultado da divisão (podendo ser arredondado).
+     */
+    protected BigDecimal divide(BigDecimal dividend, BigDecimal divisor) {
+        return divide.apply(dividend, divisor);
+    }
+
+    /**
+     * Mapeia a função de {@code round} para suportar o tipo de resultado esperado por esse collector.
+     *
+     * @param round
+     *            A função de arredondamento que será mapeada.
+     * @return Retorna a função de arredondamento mapeada de acordo com o tipo de resultado esperado para esse
+     *         collector.
+     */
+    protected abstract Function<R, R> map(Function<BigDecimal, BigDecimal> round);
+}

--- a/src/main/java/br/com/doit/commons/stream/BigDecimalAccumulator.java
+++ b/src/main/java/br/com/doit/commons/stream/BigDecimalAccumulator.java
@@ -1,0 +1,31 @@
+package br.com.doit.commons.stream;
+
+import java.math.BigDecimal;
+
+/**
+ * Classe auxiliar que funciona como acumulador de {@code BigDecimal}.
+ *
+ * @author <a href="mailto:hprange@gmail.com">Henrique Prange</a>
+ */
+class BigDecimalAccumulator {
+    public int count;
+    public BigDecimal amount;
+
+    public BigDecimalAccumulator() {
+        this(0, BigDecimal.ZERO);
+    }
+
+    public BigDecimalAccumulator(int count, BigDecimal amount) {
+        this.count = count;
+        this.amount = amount;
+    }
+
+    public void add(BigDecimal amount) {
+        count++;
+        this.amount = this.amount.add(amount);
+    }
+
+    public BigDecimalAccumulator combine(BigDecimalAccumulator acc) {
+        return new BigDecimalAccumulator(count + acc.count, amount.add(acc.amount));
+    }
+}

--- a/src/main/java/br/com/doit/commons/stream/BigDecimalAveragingCollector.java
+++ b/src/main/java/br/com/doit/commons/stream/BigDecimalAveragingCollector.java
@@ -1,0 +1,54 @@
+package br.com.doit.commons.stream;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * Collector capaz de calcular a média de elementos do tipo {@code BigDecimal}.
+ *
+ * @author <a href="mailto:hprange@gmail.com">Henrique Prange</a>
+ */
+class BigDecimalAveragingCollector extends AbstractBigDecimalCollector<BigDecimal, Optional<BigDecimal>> {
+    @Override
+    public Supplier<BigDecimalAccumulator> supplier() {
+        return BigDecimalAccumulator::new;
+    }
+
+    @Override
+    public BiConsumer<BigDecimalAccumulator, BigDecimal> accumulator() {
+        return BigDecimalAccumulator::add;
+    }
+
+    @Override
+    public BinaryOperator<BigDecimalAccumulator> combiner() {
+        return BigDecimalAccumulator::combine;
+    }
+
+    @Override
+    public Function<BigDecimalAccumulator, Optional<BigDecimal>> finisher() {
+        return acc -> {
+            if (acc.count == 0) {
+                return Optional.empty();
+            }
+
+            return Optional.of(divide(acc.amount, new BigDecimal(acc.count)));
+        };
+    }
+
+    @Override
+    public Set<Characteristics> characteristics() {
+        return Collections.unmodifiableSet(EnumSet.of(Characteristics.CONCURRENT));
+    }
+
+    @Override
+    protected Function<Optional<BigDecimal>, Optional<BigDecimal>> map(Function<BigDecimal, BigDecimal> round) {
+        return o -> o.map(round);
+    }
+}

--- a/src/main/java/br/com/doit/commons/stream/BigDecimalCollector.java
+++ b/src/main/java/br/com/doit/commons/stream/BigDecimalCollector.java
@@ -1,25 +1,14 @@
 package br.com.doit.commons.stream;
 
-import static java.util.stream.Collectors.collectingAndThen;
-
-import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.util.Optional;
-import java.util.function.BinaryOperator;
-import java.util.function.Function;
 import java.util.stream.Collector;
 
 /**
  * Essa interface adiciona métodos que fazem sentido para todos os collectors relacionados com {@code BigDecimal}.
  *
  * @author <a href="mailto:hprange@gmail.com.br">Henrique Prange</a>
- *
- * @param <A>
- *            o tipo do acumulador que é usado nas operações de redução.
  */
-public abstract class BigDecimalCollector<A> implements Collector<BigDecimal, A, Optional<BigDecimal>> {
-    private BinaryOperator<BigDecimal> divide = (dividend, divisor) -> dividend.divide(divisor);
-
+public interface BigDecimalCollector<T, A, R> extends Collector<T, A, R> {
     /**
      * Retorna um {@code Collector} que vai arredondar o valor determinado de acordo com a escala e o método de
      * arredondamento.
@@ -30,17 +19,5 @@ public abstract class BigDecimalCollector<A> implements Collector<BigDecimal, A,
      *            O método de arredondamento que será aplicado.
      * @return Retorna um {@code Collector} capaz de arredondar o valor retornado pela operação anterior.
      */
-    public Collector<BigDecimal, A, Optional<BigDecimal>> withScale(int scale, RoundingMode roundingMode) {
-        Function<Optional<BigDecimal>, Optional<BigDecimal>> rounding = o -> o.map(v -> v.setScale(scale, roundingMode));
-
-        // Isso é necessário pois uma divisão que gere uma dízima periódica deve ser arredondada no momento da divisão e
-        // não depois
-        divide = (dividend, divisor) -> dividend.divide(divisor, scale, roundingMode);
-
-        return collectingAndThen(this, rounding);
-    }
-
-    protected BigDecimal divide(BigDecimal dividend, BigDecimal divisor) {
-        return divide.apply(dividend, divisor);
-    }
+    Collector<T, A, R> withScale(int scale, RoundingMode roundingMode);
 }

--- a/src/main/java/br/com/doit/commons/stream/BigDecimalCollectors.java
+++ b/src/main/java/br/com/doit/commons/stream/BigDecimalCollectors.java
@@ -1,14 +1,8 @@
 package br.com.doit.commons.stream;
 
 import java.math.BigDecimal;
-import java.util.Collections;
-import java.util.EnumSet;
 import java.util.Optional;
-import java.util.Set;
-import java.util.function.BiConsumer;
-import java.util.function.BinaryOperator;
 import java.util.function.Function;
-import java.util.function.Supplier;
 import java.util.stream.Collector;
 
 /**
@@ -17,65 +11,25 @@ import java.util.stream.Collector;
  * @author <a href="mailto:hprange@gmail.com.br">Henrique Prange</a>
  */
 public class BigDecimalCollectors {
-    static class BigDecimalAccumulator {
-        public int count;
-        public BigDecimal amount;
-
-        public BigDecimalAccumulator() {
-            this(0, BigDecimal.ZERO);
-        }
-
-        public BigDecimalAccumulator(int count, BigDecimal amount) {
-            this.count = count;
-            this.amount = amount;
-        }
-
-        public void add(BigDecimal amount) {
-            count++;
-            this.amount = this.amount.add(amount);
-        }
-    }
-
-    public static class BigDecimalAveragingCollector extends BigDecimalCollector<BigDecimalAccumulator> {
-        @Override
-        public Supplier<BigDecimalAccumulator> supplier() {
-            return BigDecimalAccumulator::new;
-        }
-
-        @Override
-        public BiConsumer<BigDecimalAccumulator, BigDecimal> accumulator() {
-            return BigDecimalAccumulator::add;
-        }
-
-        @Override
-        public BinaryOperator<BigDecimalAccumulator> combiner() {
-            return (a1, a2) -> new BigDecimalAccumulator(a1.count + a2.count, a1.amount.add(a2.amount));
-        }
-
-        @Override
-        public Function<BigDecimalAccumulator, Optional<BigDecimal>> finisher() {
-            return acc -> {
-                if (acc.count == 0) {
-                    return Optional.empty();
-                }
-
-                return Optional.of(divide(acc.amount, new BigDecimal(acc.count)));
-            };
-        }
-
-        @Override
-        public Set<Characteristics> characteristics() {
-            return Collections.unmodifiableSet(EnumSet.of(Characteristics.CONCURRENT));
-        }
-    }
-
     /**
      * Retorna um {@code Collector} que calcula a média entre os {@code BigDecimal}s informados.
      *
-     * @return um {@code Collector} que calcula a média entre os valores fornecidos.
+     * @return Retorna um {@code Collector} que calcula a média entre os valores fornecidos.
      */
-    public static BigDecimalCollector<?> averaging() {
+    public static BigDecimalCollector<BigDecimal, ?, Optional<BigDecimal>> averaging() {
         return new BigDecimalAveragingCollector();
+    }
+
+    /**
+     * Retorna um {@code Collector} que calcula a somatória dos {@code BigDecimal}s mapeados pela função fornecida por
+     * parâmetro.
+     *
+     * @param mapper
+     *            A função que faz o mapeamento de um elemento para o valor {@code BigDecimal}.
+     * @return Retorna um {@code Collector} que calcula a somatória dos valores fornecidos.
+     */
+    public static <T> BigDecimalCollector<T, ?, BigDecimal> summing(Function<? super T, BigDecimal> mapper) {
+        return new BigDecimalSummingCollector<T>(mapper);
     }
 
     /**

--- a/src/main/java/br/com/doit/commons/stream/BigDecimalSummingCollector.java
+++ b/src/main/java/br/com/doit/commons/stream/BigDecimalSummingCollector.java
@@ -1,0 +1,53 @@
+package br.com.doit.commons.stream;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * Collector capaz de calcular a somatória de elementos que podem ser mapeados para o tipo {@code BigDecimal}.
+ *
+ * @author <a href="mailto:hprange@gmail.com">Henrique Prange</a>
+ */
+class BigDecimalSummingCollector<T> extends AbstractBigDecimalCollector<T, BigDecimal> {
+    private final Function<? super T, BigDecimal> mapper;
+
+    public BigDecimalSummingCollector(Function<? super T, BigDecimal> mapper) {
+        this.mapper = mapper;
+    }
+
+    @Override
+    public Supplier<BigDecimalAccumulator> supplier() {
+        return BigDecimalAccumulator::new;
+    }
+
+    @Override
+    public BiConsumer<BigDecimalAccumulator, T> accumulator() {
+        return (acc, o) -> acc.add(mapper.apply(o));
+    }
+
+    @Override
+    public BinaryOperator<BigDecimalAccumulator> combiner() {
+        return BigDecimalAccumulator::combine;
+    }
+
+    @Override
+    public Function<BigDecimalAccumulator, BigDecimal> finisher() {
+        return acc -> acc.amount;
+    }
+
+    @Override
+    public Set<java.util.stream.Collector.Characteristics> characteristics() {
+        return Collections.unmodifiableSet(EnumSet.of(Characteristics.CONCURRENT));
+    }
+
+    @Override
+    protected Function<BigDecimal, BigDecimal> map(Function<BigDecimal, BigDecimal> round) {
+        return round;
+    }
+}

--- a/src/test/java/br/com/doit/commons/stream/TestBigDecimalCollectors.java
+++ b/src/test/java/br/com/doit/commons/stream/TestBigDecimalCollectors.java
@@ -1,6 +1,8 @@
 package br.com.doit.commons.stream;
 
 import static br.com.doit.commons.stream.BigDecimalCollectors.averaging;
+import static br.com.doit.commons.stream.BigDecimalCollectors.summing;
+import static java.util.function.Function.identity;
 import static java.util.stream.Stream.concat;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
@@ -61,5 +63,47 @@ public class TestBigDecimalCollectors {
 
         assertThat(result.isPresent(), is(true));
         assertThat(result.get(), is(new BigDecimal("2.3")));
+    }
+
+    @Test
+    public void summingWhenStreamReturnsNoElements() throws Exception {
+        BigDecimal result = Stream.<BigDecimal> empty().collect(summing(identity()));
+
+        assertThat(result, is(BigDecimal.ZERO));
+    }
+
+    @Test
+    public void summingWhenStreamReturnsOneElement() throws Exception {
+        BigDecimal result = Stream.of(BigDecimal.ONE).collect(summing(identity()));
+
+        assertThat(result, is(BigDecimal.ONE));
+    }
+
+    @Test
+    public void summingWhenStreamReturnsTwoElements() throws Exception {
+        BigDecimal result = Stream.of(BigDecimal.ONE, BigDecimal.TEN).collect(summing(identity()));
+
+        assertThat(result, is(new BigDecimal("11")));
+    }
+
+    @Test
+    public void summingCombineResultWhenStreamCombinedWithAnotherInParallel() throws Exception {
+        BigDecimal result = concat(Stream.of(BigDecimal.ONE).parallel(), Stream.of(BigDecimal.TEN).parallel()).collect(summing(identity()));
+
+        assertThat(result, is(new BigDecimal("11")));
+    }
+
+    @Test
+    public void summingApplyFunctionWhenStreamContainsObjects() throws Exception {
+        BigDecimal result = Stream.of(Optional.of(BigDecimal.ONE)).collect(summing(Optional::get));
+
+        assertThat(result, is(BigDecimal.ONE));
+    }
+
+    @Test
+    public void roundValueWhenSummingWithScaleAndRoundMode() throws Exception {
+        BigDecimal result = Stream.of(new BigDecimal("0.41"), new BigDecimal("0.31")).collect(summing(identity()).withScale(1, RoundingMode.HALF_EVEN));
+
+        assertThat(result, is(new BigDecimal("0.7")));
     }
 }


### PR DESCRIPTION
Esse `Collector` pode ser utilizado em operações de agrupamento em que é preciso fazer o somatório de valores do tipo `BigDecimal`.

Exemplo de uso:

```java
NSArray<AccountingEntries> entries;

Map<NSTimestamp, BigDecimal> balancesByDueDate = entries.stream()
                .collect(groupingBy(this::dueDate, summing(AccountingEntry::balance)));
```