### PR TITLE
Alteração deixando Default Locale em Messages fique independente do idioma default do sistema operacional.

### DIFF
--- a/src/main/java/br/com/doit/commons/l10n/Messages.java
+++ b/src/main/java/br/com/doit/commons/l10n/Messages.java
@@ -47,7 +47,7 @@ public class Messages {
      */
     public static Messages getMessages(String resourceBundleName) {
         // Verifica se o ResourceBundle existe
-        ResourceBundle.getBundle(resourceBundleName);
+        Messages.getBundle(resourceBundleName);
 
         return new Messages(resourceBundleName);
     }
@@ -112,12 +112,19 @@ public class Messages {
     }
 
     private ResourceBundle messages() {
-        Locale locale = localeSupplier != null ? localeSupplier.get() : Locale.getDefault();
-
         if (!isCacheEnabled) {
             ResourceBundle.clearCache();
         }
 
-        return ResourceBundle.getBundle(resourceBundleName, locale);
+        return Messages.getBundle(resourceBundleName);
     }
+
+    private static ResourceBundle getBundle(String resourceBundleName) {
+        return ResourceBundle.getBundle(resourceBundleName, locale());
+    }
+
+    private static Locale locale() {
+        return localeSupplier != null ? localeSupplier.get() : Locale.getDefault();
+    }
+
 }

--- a/src/test/java/br/com/doit/commons/basic/AbstractMessageTestCase.java
+++ b/src/test/java/br/com/doit/commons/basic/AbstractMessageTestCase.java
@@ -1,0 +1,16 @@
+package br.com.doit.commons.basic;
+
+import java.util.Locale;
+
+import org.junit.Before;
+
+import br.com.doit.commons.l10n.Messages;
+
+public abstract class AbstractMessageTestCase {
+
+    @Before
+    public void prepareLocale() {
+        Messages.setSupplierOfLocale(() -> Locale.ENGLISH);
+    }
+
+}

--- a/src/test/java/br/com/doit/commons/excel/TestExcelErrorMessageFormatter.java
+++ b/src/test/java/br/com/doit/commons/excel/TestExcelErrorMessageFormatter.java
@@ -8,12 +8,14 @@ import static org.mockito.Mockito.when;
 import org.apache.poi.ss.usermodel.Cell;
 import org.junit.Test;
 
+import br.com.doit.commons.basic.AbstractMessageTestCase;
 import br.com.doit.commons.excel.ExcelImporter.ExcelErrorMessageFormatter;
 
 /**
  * @author <a href="mailto:hprange@gmail.com.br">Henrique Prange</a>
  */
-public class TestExcelErrorMessageFormatter {
+public class TestExcelErrorMessageFormatter extends AbstractMessageTestCase {
+
     @Test
     public void formatColumnOneToLetterAWhenFormattingMessage() throws Exception {
         Cell cell = mock(Cell.class);

--- a/src/test/java/br/com/doit/commons/l10n/TestMessages.java
+++ b/src/test/java/br/com/doit/commons/l10n/TestMessages.java
@@ -17,10 +17,12 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import br.com.doit.commons.basic.AbstractMessageTestCase;
+
 /**
  * @author <a href="mailto:hprange@gmail.com">Henrique Prange</a>
  */
-public class TestMessages {
+public class TestMessages extends AbstractMessageTestCase {
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
@@ -62,7 +64,7 @@ public class TestMessages {
     @Test
     public void throwExceptionWhenResourceBundleNotFound() throws Exception {
         thrown.expect(MissingResourceException.class);
-        thrown.expectMessage(is("Can't find bundle for base name br/com/doit/commons/test/notfound, locale en_US"));
+        thrown.expectMessage(is("Can't find bundle for base name br/com/doit/commons/test/notfound, locale en"));
 
         Messages.getMessages("br/com/doit/commons/test/notfound");
     }


### PR DESCRIPTION
Sugestão de alteração para deixar Default Locale em Message mais flexível.

Quando o sistema operacional esta em um idioma diferente do inglês, no método Messages.getMessages ele verifica se existe o ResourceBundle, porém ele irá procurar um arquivo baseado no idioma padrão do sistema.

Então fiz uma alteração para que ele obedeça o Locale setado através do Messages.setSupplierOfLocale.