### PR TITLE
Remove tabs do meio do texto

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	</parent>
 
 	<artifactId>doit-commons</artifactId>
-	<version>0.3-SNAPSHOT</version>
+	<version>0.2.2</version>
 	<name>DOit Commons Framework</name>
 	<description>Framework que contém funcionalidades comuns utilizadas em vários projetos da DOit.</description>
 
@@ -42,5 +42,6 @@
 		<connection>scm:git:ssh://git@github.com/doitsa/doit-commons.git</connection>
 		<url>scm:git:ssh://git@github.com/doitsa/doit-commons.git</url>
 		<developerConnection>scm:git:ssh://git@github.com/doitsa/doit-commons.git</developerConnection>
-	</scm>
+	  <tag>doit-commons-0.2.2</tag>
+  </scm>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,8 @@
 	</build>
 
 	<scm>
-        <connection>scm:git:ssh://git@github.com/doitsa/doit-commons.git</connection>
-        <url>scm:git:ssh://git@github.com/doitsa/doit-commons.git</url>
-        <developerConnection>scm:git:ssh://git@github.com/doitsa/doit-commons.git</developerConnection>
-    </scm>
+		<connection>scm:git:ssh://git@github.com/doitsa/doit-commons.git</connection>
+		<url>scm:git:ssh://git@github.com/doitsa/doit-commons.git</url>
+		<developerConnection>scm:git:ssh://git@github.com/doitsa/doit-commons.git</developerConnection>
+	</scm>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	</parent>
 
 	<artifactId>doit-commons</artifactId>
-	<version>0.2.2</version>
+	<version>0.3-SNAPSHOT</version>
 	<name>DOit Commons Framework</name>
 	<description>Framework que contém funcionalidades comuns utilizadas em vários projetos da DOit.</description>
 
@@ -42,6 +42,6 @@
 		<connection>scm:git:ssh://git@github.com/doitsa/doit-commons.git</connection>
 		<url>scm:git:ssh://git@github.com/doitsa/doit-commons.git</url>
 		<developerConnection>scm:git:ssh://git@github.com/doitsa/doit-commons.git</developerConnection>
-	  <tag>doit-commons-0.2.2</tag>
+	  <tag>HEAD</tag>
   </scm>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,17 @@
 		</dependency>
 	</dependencies>
 
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-release-plugin</artifactId>
+				<version>2.5.3</version>
+			</plugin>
+		</plugins>
+	</build>
+
 	<scm>
         <connection>scm:git:ssh://git@github.com/doitsa/doit-commons.git</connection>
         <url>scm:git:ssh://git@github.com/doitsa/doit-commons.git</url>

--- a/src/main/java/br/com/doit/commons/text/TextNormalizerUtils.java
+++ b/src/main/java/br/com/doit/commons/text/TextNormalizerUtils.java
@@ -24,12 +24,16 @@ public class TextNormalizerUtils {
             return null;
         }
 
-        return toAscii(text).replaceAll("[^a-zA-Z0-9\\s\\.:-]", "").replaceAll("\n", "").trim();
+        return stripChars(stripChars(toAscii(text), "[^a-zA-Z0-9\\s\\.:-]"), "[\\n\\t]").trim();
+    }
+
+    private static String stripChars(String text, String pattern) {
+        return text.replaceAll(pattern, "");
     }
 
     /**
      * Remove todos os caracteres não alfanuméricos do texto.
-     * 
+     *
      * @param text
      *            O texto que deverá ser tratado
      * @return Retorna o texto contendo apenas caracteres alfanuméricos
@@ -39,7 +43,7 @@ public class TextNormalizerUtils {
             return null;
         }
 
-        return toAscii(text).replaceAll("[^a-zA-Z0-9\\s]", "").replaceAll("\n", "").trim();
+        return stripChars(stripChars(toAscii(text), "[^a-zA-Z0-9\\s]"), "[\\n\\t]").trim();
     }
 
     /**

--- a/src/test/java/br/com/doit/commons/text/TestTextNormalizerUtils.java
+++ b/src/test/java/br/com/doit/commons/text/TestTextNormalizerUtils.java
@@ -18,6 +18,13 @@ public class TestTextNormalizerUtils {
     }
 
     @Test
+    public void lightStripTabsFromTheMiddleOfWords() throws Exception {
+        String result = TextNormalizerUtils.lightStripNonAlphanumericChars("abc \t def");
+
+        assertThat(result, is("abc  def"));
+    }
+
+    @Test
     public void normalizeNullString() throws Exception {
         String result = TextNormalizerUtils.toAscii(null);
 
@@ -75,6 +82,13 @@ public class TestTextNormalizerUtils {
         String result = TextNormalizerUtils.stripNonNumericChars("123.456.789-09ABC");
 
         assertThat(result, is("12345678909"));
+    }
+
+    @Test
+    public void stripTabsFromTheMiddleOfWords() throws Exception {
+        String result = TextNormalizerUtils.stripNonAlphanumericChars("abc \t def");
+
+        assertThat(result, is("abc  def"));
     }
 
     @Test


### PR DESCRIPTION
As funções que removem caracteres especiais também vão remover tabs do meio do texto.

Isso vai resolver um problema ao emitir notas fiscais.